### PR TITLE
fix(oxid): dont return an error on getUser when status is 403 because…

### DIFF
--- a/packages/storefront-shop-adapter-oxid/src/providers/user.ts
+++ b/packages/storefront-shop-adapter-oxid/src/providers/user.ts
@@ -128,6 +128,19 @@ export class StorefrontShopAdapterOxidUser implements MakairaShopProviderUser {
           path: USER_GET_CURRENT,
         })
 
+      // oxid returns an 403 if no user is logged in. Therefore
+      // return an empty user without error
+      if (
+        status === 403 &&
+        (response as { message: string }).message === 'Forbidden'
+      ) {
+        return {
+          data: undefined,
+          raw: { getUser: response },
+          error: undefined,
+        }
+      }
+
       if (status !== 200 || (response as { message: string }).message) {
         return {
           data: undefined,


### PR DESCRIPTION
… it indicates no user