### PR TITLE
fix(shopify): apply inContext to all queries

### DIFF
--- a/packages/storefront-shop-adapter-shopify/src/providers/cart.queries.ts
+++ b/packages/storefront-shop-adapter-shopify/src/providers/cart.queries.ts
@@ -1,3 +1,4 @@
+import { getInContextAnnotation } from '../utils/getInContextAnnotation'
 import { ContextOptions, StorefrontShopifyFragments } from '../types'
 
 export type LineItemInput = {
@@ -97,22 +98,10 @@ export const CheckoutCreateMutation = ({
   checkoutFragment: string
   contextOptions?: ContextOptions | null
 }) => {
-  let inContext = ''
-  if (contextOptions !== null) {
-    const contextParams = []
-    for (const key of Object.keys(contextOptions)) {
-      contextParams.push(
-        `${key}: ${contextOptions[key as keyof typeof contextOptions]}`
-      )
-    }
-
-    if (contextParams.length > 0) {
-      inContext = `@inContext(${contextParams.join()})`
-    }
-  }
+  const inContextAnnotation = getInContextAnnotation(contextOptions)
 
   return `
-  mutation checkoutCreate($input: CheckoutCreateInput!) ${inContext} {
+  mutation checkoutCreate($input: CheckoutCreateInput!) ${inContextAnnotation} {
       checkoutCreate(input: $input) {
           checkoutUserErrors {
               ...CheckoutUserErrorFragment
@@ -147,10 +136,12 @@ export type CheckoutCreateMutationData = {
 
 export const CheckoutGetQuery = ({
   checkoutFragment,
+  contextOptions = {},
 }: {
   checkoutFragment: string
+  contextOptions?: ContextOptions | null
 }) => `
-    query node($id: ID!) {
+    query node($id: ID!) ${getInContextAnnotation(contextOptions)} {
         node(id: $id) {
             ...CheckoutFragment
         }
@@ -173,11 +164,15 @@ export type CheckoutGetQueryData = {
 export const CheckoutLineItemsAddMutation = ({
   checkoutUserErrorFragment,
   checkoutFragment,
+  contextOptions = {},
 }: {
   checkoutUserErrorFragment: string
   checkoutFragment: string
+  contextOptions?: ContextOptions | null
 }) => `
-    mutation ($checkoutId: ID!, $lineItems: [CheckoutLineItemInput!]!) {
+    mutation ($checkoutId: ID!, $lineItems: [CheckoutLineItemInput!]!) ${getInContextAnnotation(
+      contextOptions
+    )} {
       checkoutLineItemsAdd(checkoutId: $checkoutId, lineItems: $lineItems) {
           checkoutUserErrors {
               ...CheckoutUserErrorFragment
@@ -210,11 +205,15 @@ export type CheckoutLineItemsAddMutationData = {
 export const CheckoutLineItemsRemoveMutation = ({
   checkoutUserErrorFragment,
   checkoutFragment,
+  contextOptions = {},
 }: {
   checkoutUserErrorFragment: string
   checkoutFragment: string
+  contextOptions?: ContextOptions | null
 }) => `
-mutation ($checkoutId: ID!, $lineItemIds: [ID!]!) {
+mutation ($checkoutId: ID!, $lineItemIds: [ID!]!) ${getInContextAnnotation(
+  contextOptions
+)} {
   checkoutLineItemsRemove(checkoutId: $checkoutId, lineItemIds: $lineItemIds) {
       checkoutUserErrors {
           ...CheckoutUserErrorFragment
@@ -247,11 +246,15 @@ export type CheckoutLineItemsRemoveMutationData = {
 export const CheckoutLineItemsUpdateMutation = ({
   checkoutUserErrorFragment,
   checkoutFragment,
+  contextOptions = {},
 }: {
   checkoutUserErrorFragment: string
   checkoutFragment: string
+  contextOptions?: ContextOptions | null
 }) => `
-mutation ($checkoutId: ID!, $lineItems: [CheckoutLineItemUpdateInput!]!) {
+mutation ($checkoutId: ID!, $lineItems: [CheckoutLineItemUpdateInput!]!) ${getInContextAnnotation(
+  contextOptions
+)} {
   checkoutLineItemsUpdate(checkoutId: $checkoutId, lineItems: $lineItems) {
       checkoutUserErrors {
           ...CheckoutUserErrorFragment

--- a/packages/storefront-shop-adapter-shopify/src/providers/cart.ts
+++ b/packages/storefront-shop-adapter-shopify/src/providers/cart.ts
@@ -92,6 +92,7 @@ export class StorefrontShopAdapterShopifyCart
         query: CheckoutGetQuery({
           checkoutFragment:
             this.mainAdapter.additionalOptions.fragments.checkoutFragment,
+          contextOptions: this.mainAdapter.getContextOptions(),
         }),
         variables: { id: storedCheckoutId },
       })
@@ -186,6 +187,7 @@ export class StorefrontShopAdapterShopifyCart
           checkoutUserErrorFragment:
             this.mainAdapter.additionalOptions.fragments
               .checkoutUserErrorFragment,
+          contextOptions: this.mainAdapter.getContextOptions(),
         }),
         variables: { checkoutId, lineItems },
       })
@@ -293,6 +295,7 @@ export class StorefrontShopAdapterShopifyCart
             checkoutUserErrorFragment:
               this.mainAdapter.additionalOptions.fragments
                 .checkoutUserErrorFragment,
+            contextOptions: this.mainAdapter.getContextOptions(),
           }),
           variables: { checkoutId, lineItemIds },
         })
@@ -402,6 +405,7 @@ export class StorefrontShopAdapterShopifyCart
               checkoutUserErrorFragment:
                 this.mainAdapter.additionalOptions.fragments
                   .checkoutUserErrorFragment,
+              contextOptions: this.mainAdapter.getContextOptions(),
             }),
             variables: {
               checkoutId,

--- a/packages/storefront-shop-adapter-shopify/src/utils/getInContextAnnotation.ts
+++ b/packages/storefront-shop-adapter-shopify/src/utils/getInContextAnnotation.ts
@@ -1,0 +1,17 @@
+import { ContextOptions } from '../types'
+
+export function getInContextAnnotation(contextOptions: ContextOptions | null) {
+  let inContext = ''
+  if (contextOptions !== null) {
+    const contextParams: Array<string> = []
+    for (const [key, value] of Object.entries(contextOptions)) {
+      contextParams.push(`${key}: ${value}`)
+    }
+
+    if (contextParams.length > 0) {
+      inContext = `@inContext( ${contextParams.join(', ')} )`
+    }
+  }
+
+  return inContext
+}


### PR DESCRIPTION
When `@inContext` is not specified on a query or mutation, Shopify will always send the main prices and the main currency of the shop.

**Example:**
Shop A has two currencies: Euro (main) and US Dollar (market)
Product A has two prices: 60 € & $80

Performing any mutation or query without the `@inContext` option will always yield the price in the main currency (`60€`), even if the checkout creation had an `@inContext` annotation specifying the other currency.