### PR TITLE
fix(shopify): add line item id to updateItem input

### DIFF
--- a/packages/storefront-shop-adapter-shopify/Readme.md
+++ b/packages/storefront-shop-adapter-shopify/Readme.md
@@ -119,7 +119,9 @@ _No additional properties_
 
 #### updateItem
 
-_No additional properties_
+| Property   | Required/Optional | Description                                                                                                                                                                                            | Type     |
+| ---------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| lineItemId | required          | In Shopify it is not possible to update a product in the shopping cart only by its variantId. Instead both IDs are required. The `lineItemId` can be accessed through the `raw` property on `getCart`. | `string` |
 
 ### Review
 


### PR DESCRIPTION
The `updateItem` method of the cart in the Shopify adapter didn't work correctly - the reason was a missing field in the input (see [the docs](https://shopify.dev/docs/api/storefront/2022-07/mutations/checkoutLineItemsUpdate#top)).
This MR adds the field as an additional required input and updates the readme accordingly to reflect this change.